### PR TITLE
Added ruby to resuable sbom, updated secrets, updated knife commands …

### DIFF
--- a/.github/workflows/publish.chefsupermaket.yml
+++ b/.github/workflows/publish.chefsupermaket.yml
@@ -3,77 +3,43 @@ on:
   workflow_dispatch:
 
 jobs:
-  generate-sbom:
+  get-version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
     steps:
-      - name: Get the source code
-        uses: actions/checkout@v3
-
-      - name: Install Syft
+      - uses: actions/checkout@v4
+      - name: Extract version from metadata.rb
+        id: extract-version
+        working-directory: ./integration/keeper_secrets_manager_chef/cookbooks/keeper_secrets_manager
         run: |
-          echo "Installing Syft v1.18.1..."
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /tmp/bin v1.18.1
-          echo "/tmp/bin" >> $GITHUB_PATH
-
-      - name: Install Manifest CLI
-        run: |
-          echo "Installing Manifest CLI v0.18.3..."
-          curl -sSfL https://raw.githubusercontent.com/manifest-cyber/cli/main/install.sh | sh -s -- -b /tmp/bin v0.18.3
-
-      - name: Create Syft configuration
-        run: |
-          cat > syft-config.yaml << 'EOF'
-          package:
-            search:
-              scope: all-layers
-              exclude:
-                - "**/test/**"
-                - "**/spec/**"
-            cataloger:
-              enabled: true
-              ruby:
-                enabled: true
-                search-gems: true
-              java:
-                enabled: false
-              python:
-                enabled: false
-              nodejs:
-                enabled: false
-          EOF
-
-      - name: Generate and upload SBOM
-        env:
-          MANIFEST_API_KEY: ${{ secrets.MANIFEST_TOKEN }}
-        run: |
-          CHEF_COOKBOOK_DIR="./integration/keeper_secrets_manager_chef/cookbooks/keeper_secrets_manager"
-
           echo "Detecting Chef cookbook version..."
-          if [ -f "${CHEF_COOKBOOK_DIR}/metadata.rb" ]; then
-            VERSION=$(grep "version" "${CHEF_COOKBOOK_DIR}/metadata.rb" | awk '{print $2}' | tr -d "'\"")
+          if [ -f "metadata.rb" ]; then
+            VERSION=$(grep "version" "metadata.rb" | awk '{print $2}' | tr -d "'\"")
             echo "Detected version: ${VERSION}"
           else
             VERSION="1.0.0"
             echo "Could not detect version, using default: ${VERSION}"
           fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+  
 
-          echo "Generating SBOM with Manifest CLI..."
-          /tmp/bin/manifest sbom "${CHEF_COOKBOOK_DIR}" \
-            --generator=syft \
-            --name=keeper-secrets-manager-chef \
-            --version=${VERSION} \
-            --output=spdx-json \
-            --file=chef-cookbook-sbom.json \
-            --api-key=${MANIFEST_API_KEY} \
-            --publish=true \
-            --asset-label=application,sbom-generated,ruby,chef \
-            --generator-config=syft-config.yaml
+  generate-and-upload-sbom:
+    needs: get-version
+    uses: ./.github/workflows/reusable.sbom.workflow.yml
+    with:
+      working-directory: ./integration/keeper_secrets_manager_chef/cookbooks/keeper_secrets_manager
+      project-name: keeper-secrets-manager-chef
+      project-type: ruby
+      project-version: ${{ needs.get-version.outputs.version }}
+      sbom-format: spdx-json
+      additional-labels: application,sbom-generated,ruby,chef
+    secrets:
+      MANIFEST_TOKEN: ${{ secrets.MANIFEST_TOKEN }}
 
-          echo "SBOM generated and uploaded successfully: chef-cookbook-sbom.json"
-          head -n 20 chef-cookbook-sbom.json
 
   publish-chef-supermarket:
-    needs: generate-sbom
+    needs: generate-and-upload-sbom
     runs-on: ubuntu-latest
     environment: prod
     timeout-minutes: 20
@@ -95,9 +61,9 @@ jobs:
         id: ksmsecrets
         uses: Keeper-Security/ksm-action@master
         with:
-          keeper-secret-config: ${{ secrets.KSM_KSM_CONFIG }}
+          keeper-secret-config: ${{ secrets.KSM_CHEF_SUPERMARKET_CONFIG }}
           secrets: |
-            <your_keeper_uid_here>/field/password > CHEF_SUPERMARKET_API_KEY
+            ${{ secrets.CHEF_SUPERMARKET_RECORD_UID }}/field/password > CHEF_SUPERMARKET_API_KEY
 
       - name: Get current version and validate
         id: version
@@ -128,7 +94,7 @@ jobs:
           echo "Installing Chef Workstation..."
           curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef-workstation
           chef --version
-      
+
       - name: Run linting (Cookstyle)
         run: |
           echo "Running cookstyle..."
@@ -148,7 +114,7 @@ jobs:
           knife supermarket share keeper_secrets_manager "Utilities" \
             --supermarket-site https://supermarket.chef.io \
             --cookbook-path . \
-            
+          
           echo "Successfully published to Chef Supermarket!"
 
       - name: Create release summary

--- a/.github/workflows/reusable.sbom.workflow.yml
+++ b/.github/workflows/reusable.sbom.workflow.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       project-type:
-        description: 'Type of project (python, dotnet, nodejs)'
+        description: 'Type of project (python, dotnet, nodejs, java, ruby)'
         required: true
         type: string
       project-version:
@@ -74,6 +74,12 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
+
+      - name: Setup Ruby
+        if: inputs.project-type == 'ruby'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.4'
 
 
       - name: Detect project version
@@ -235,7 +241,60 @@ jobs:
             else
               echo "package.json not found"
             fi
-          
+
+            echo "::endgroup::"
+            return 1
+          }
+
+          detect_ruby_version() {
+            echo "::group::Ruby Version Detection"
+
+            # Try metadata.rb (Chef cookbooks)
+            if [ -f "metadata.rb" ]; then
+              echo "Found metadata.rb, attempting to extract version..."
+              metadata_version=$(grep -Po "^version\\s+['\"]\\K[^'\"]*" metadata.rb 2>/dev/null || echo "")
+              if [ ! -z "$metadata_version" ]; then
+                echo "✓ Successfully extracted version from metadata.rb: $metadata_version"
+                echo "::endgroup::"
+                echo "$metadata_version"
+                return 0
+              else
+                echo "⚠ Failed to extract version from metadata.rb"
+              fi
+            else
+              echo "metadata.rb not found"
+            fi
+
+            # Try .gemspec files
+            echo "Searching for .gemspec files..."
+            find . -name "*.gemspec" -type f -print0 | while IFS= read -r -d '' file; do
+              echo "Checking $file for version..."
+              gemspec_version=$(grep -Po "version\\s*=\\s*['\"]\\K[^'\"]*" "$file" 2>/dev/null || echo "")
+              if [ ! -z "$gemspec_version" ]; then
+                echo "✓ Successfully extracted version from $file: $gemspec_version"
+                echo "::endgroup::"
+                echo "$gemspec_version"
+                return 0
+              fi
+            done
+            echo "⚠ No version found in any .gemspec files"
+
+            # Try VERSION file
+            if [ -f "VERSION" ]; then
+              echo "Found VERSION file, attempting to extract version..."
+              version_file=$(cat VERSION 2>/dev/null | tr -d '\\n\\r' | head -1)
+              if [ ! -z "$version_file" ]; then
+                echo "✓ Successfully extracted version from VERSION file: $version_file"
+                echo "::endgroup::"
+                echo "$version_file"
+                return 0
+              else
+                echo "⚠ VERSION file is empty"
+              fi
+            else
+              echo "VERSION file not found"
+            fi
+
             echo "::endgroup::"
             return 1
           }
@@ -249,6 +308,9 @@ jobs:
               ;;
             "nodejs")
               VERSION=$(detect_nodejs_version)
+              ;;
+            "ruby")
+              VERSION=$(detect_ruby_version)
               ;;
             "java")
               if [ -f "build.gradle.kts" ]; then
@@ -322,15 +384,15 @@ jobs:
           
           echo "Building project to download dependencies"
           ./gradlew build --no-daemon --refresh-dependencies
-
-    
+          
+          
           cat syft-config.yaml
           echo "Syft version:"
           syft version
           
           echo "Full project scan with verbose output:"
           SYFT_LOG_LEVEL=debug syft packages . -c syft-config.yaml -o json | tee syft-scan.json
-    
+          
           echo "Scanning Gradle cache:"
           find ~/.gradle/caches/modules-2 -type f -name "*.jar" | while read -r jar; do
             echo "Found JAR: $jar"
@@ -448,7 +510,25 @@ jobs:
           fi
 
           echo "Creating Syft config for Manifest"
-          cat > syft-config.yaml << 'EOF'
+          if [ "${{ inputs.project-type }}" = "ruby" ]; then
+            cat > syft-config.yaml << 'EOF'
+          package:
+            search:
+              scope: all-layers
+            cataloger:
+              enabled: true
+              ruby:
+                enabled: true
+                search-gems: true
+              java:
+                enabled: false
+              python:
+                enabled: false
+              nodejs:
+                enabled: false
+          EOF
+          else
+            cat > syft-config.yaml << 'EOF'
           package:
             search:
               scope: all-layers
@@ -459,6 +539,7 @@ jobs:
                 search-indexed-archives: true
                 resolve-dependencies: true
           EOF
+          fi
           # Generate SBOM using Manifest CLI
           "$MANIFEST_PATH" sbom . \
             --generator=syft \

--- a/integration/keeper_secrets_manager_chef/cookbooks/README.md
+++ b/integration/keeper_secrets_manager_chef/cookbooks/README.md
@@ -19,12 +19,12 @@ The Keeper Secrets Manager cookbook allows Chef-managed nodes to integrate with 
 ## Prerequisites
 
 * Keeper Secrets Manager access (See the [Quick Start Guide](https://docs.keeper.io/secrets-manager/secrets-manager/quick-start-guide) for more details)
-  * Secrets Manager add-on enabled for your Keeper subscription
-  * Membership in a Role with the Secrets Manager enforcement policy enabled
+    * Secrets Manager add-on enabled for your Keeper subscription
+    * Membership in a Role with the Secrets Manager enforcement policy enabled
 * A Keeper Secrets Manager Application with secrets shared to it
-  * See the Quick Start Guide for instructions on creating an Application
+    * See the Quick Start Guide for instructions on creating an Application
 * An initialized Keeper Secrets Manager Configuration
-  * The cookbook accepts Base64 format configurations
+    * The cookbook accepts Base64 format configurations
 
 ## Installation
 
@@ -33,13 +33,13 @@ The Keeper Secrets Manager cookbook allows Chef-managed nodes to integrate with 
 Add this line to your `Berksfile`:
 
 ```ruby
-cookbook 'keeper_secrets_manager', git: 'https://github.com/your-org/keeper_secrets_manager.git'
+cookbook 'keeper_secrets_manager', git: 'https://github.com/Keeper-Security/secrets-manager.git', rel: 'integration/keeper_secrets_manager_chef/cookbooks/keeper_secrets_manager'
 ```
 
 ### Using Chef Supermarket
 
 ```bash
-knife cookbook site install keeper_secrets_manager
+knife supermarket install keeper_secrets_manager
 ```
 
 ### Manual Installation


### PR DESCRIPTION
…in readme. 

We have a reusable sbom workflow that I updated to work with ruby related files. I added it to the publish chef workflow, alongside other Secrets that Keeper will need to add to the main secrets-manager repo to let the flow work. 
Secrets needed: 
MANIFEST_TOKEN - already in the main repo for sbom generation
KSM_CHEF_SUPERMARKET_CONFIG - access json for using ksm-action to retrieve secrets from vault
CHEF_SUPERMARKET_RECORD_UUID - the path in the vault to where the chef supermarket api key, which we will have to create and upload

